### PR TITLE
DApp- BUMP-SDK-VERSION-TO-1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@mui/material": "^5.5.0",
     "@pushprotocol/restapi": "1.7.20",
     "@pushprotocol/socket": "0.5.3",
-    "@pushprotocol/uiweb": "1.6.0-alpha.3",
+    "@pushprotocol/uiweb": "1.3.7",
     "@reduxjs/toolkit": "^1.7.1",
     "@testing-library/dom": "^9.0.1",
     "@testing-library/jest-dom": "^4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,9 +4000,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pushprotocol/uiweb@npm:1.6.0-alpha.3":
-  version: 1.6.0-alpha.3
-  resolution: "@pushprotocol/uiweb@npm:1.6.0-alpha.3"
+"@pushprotocol/uiweb@npm:1.3.7":
+  version: 1.3.7
+  resolution: "@pushprotocol/uiweb@npm:1.3.7"
   dependencies:
     "@livekit/components-react": "npm:^1.2.2"
     "@livekit/components-styles": "npm:^1.0.6"
@@ -4044,7 +4044,7 @@ __metadata:
     react-dom: 17.0.2
     styled-components: ^6.0.8
     viem: ^1.3.0
-  checksum: 10/9cd732dbb2aac3cc8636705366739b6d15acab802406ab8f27981764a59534663d34ba7dd201a7732de87ab27cc137962d5fcd08ece59240cacae884171e9068
+  checksum: 10/c3978e88df4d9d1991941454d03ce01a7c6e1f43577acd9f39228203425d82dd3a2ed0d2964eb106537d1697277fd91642d8a8c01a01e017703b1ec7f0ed9bac
   languageName: node
   linkType: hard
 
@@ -17681,7 +17681,7 @@ __metadata:
     "@mui/material": "npm:^5.5.0"
     "@pushprotocol/restapi": "npm:1.7.20"
     "@pushprotocol/socket": "npm:0.5.3"
-    "@pushprotocol/uiweb": "npm:1.6.0-alpha.3"
+    "@pushprotocol/uiweb": "npm:1.3.7"
     "@reduxjs/toolkit": "npm:^1.7.1"
     "@testing-library/dom": "npm:^9.0.1"
     "@testing-library/jest-dom": "npm:^4.2.4"


### PR DESCRIPTION
Bumping the version of uiweb to 1.3.7 for prod deployment