### PR TITLE
Missing Notification Issue fixed

### DIFF
--- a/src/segments/Inbox.tsx
+++ b/src/segments/Inbox.tsx
@@ -132,7 +132,6 @@ const Inbox = ({ showFilter, setShowFilter, search, setSearch }) => {
   };
 
   useEffect(() => {
-    // console.log(allFilter)
     setFilteredNotifications(allFilter);
   }, [allFilter]);
 
@@ -161,6 +160,7 @@ const Inbox = ({ showFilter, setShowFilter, search, setSearch }) => {
     setBgUpdateLoading(true);
     setLoading(true);
     try {
+
       const results = await userPushSDKInstance.notification.list('INBOX', {
         raw: true,
         page: 1,
@@ -206,9 +206,7 @@ const Inbox = ({ showFilter, setShowFilter, search, setSearch }) => {
         page: page,
         raw: true,
       });
-      if (!notifications.length) {
-        dispatch(incrementPage());
-      }
+
       const parsedResponse = pushApiUtils.parseApiResponse(results);
       const map1 = new Map();
       const map2 = new Map();
@@ -241,7 +239,6 @@ const Inbox = ({ showFilter, setShowFilter, search, setSearch }) => {
       setLimit(limit + 10);
     } else {
       loadNotifications();
-      dispatch(incrementPage());
     }
   };
 


### PR DESCRIPTION
## Pull Request Template

#1592 

### Description

Some notifications were missing in the Inbox Channel Page. So here's what I did:

- When the Inbox is loaded so fetchNotifications is called and after that it increases the page number by 1.
- When the user reaches the bottom of the Inbox so loadNotifications is called and after the response is fetched it increments the page by 1.
- In this way, page is incremented by 1 and thus notifications are called in a proper manner.

*No change in the Redux state management.*

- **Problem/Feature**:

### Type of Change


- [x] Bug fix

### Checklist

- [x] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [ ] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [ ] No errors in the build terminal
- [ ] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Explain the previous behavior
<img width="673" alt="Screenshot 2024-06-03 at 3 39 58 PM" src="https://github.com/push-protocol/push-dapp/assets/77395788/d04290bb-1ca3-408c-9acc-4d775dce409f">

- For developers, you can test this in the networks tab where the page is not incremented by 1 but it increments by 2. So, notifications are missing.


- **After:** What's changed now
<img width="1470" alt="Screenshot 2024-06-03 at 3 39 09 PM" src="https://github.com/push-protocol/push-dapp/assets/77395788/2cd8d371-7ff1-42ea-b954-f154b5a3a373">

### Additional Context

### Review & Approvals

- [ ] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable