### PR TITLE
Added gap and fixed padding/margin prop in the box component

### DIFF
--- a/src/blocks/Blocks.types.ts
+++ b/src/blocks/Blocks.types.ts
@@ -22,7 +22,7 @@ export type ResponsiveProp<T> = T | { [key in Breakpoint]?: T };
 
 export type RadiusType = `r${number}`;
 
-export type SpaceType = `s${number}`;
+export type SpaceType = `s${number}` | `s${number} s${number}`| `s${number} s${number} s${number} s${number}`;
 
 export type PixelValue = `${number}px`;
 

--- a/src/blocks/Blocks.utils.ts
+++ b/src/blocks/Blocks.utils.ts
@@ -7,7 +7,7 @@ import {
   CSSPropValueType,
   DeviceSizeName,
   PixelValue,
-  ResponsiveCSSPropertyData,
+  ResponsiveCSSPropertyData
 } from './Blocks.types';
 
 /**
@@ -16,8 +16,14 @@ import {
  * @returns value of a CSS property
  */
 const getCSSValue = (propName: CSSPropName, value: CSSPropValueType | undefined) => {
-  const propsWithCssVariables = ['padding', 'margin', 'border-radius'];
-  return propsWithCssVariables.includes(propName) ? `var(--${value})` : value;
+  if (propName === 'padding' || propName === 'margin') {
+    if (typeof value === 'string') {
+      return value.replace(/\b(\w+)\b/g, 'var(--$1)');
+    }
+  } else if (propName === 'gap') {
+    return `var(--${value})`;
+  }
+  return value;
 };
 
 /**
@@ -99,7 +105,7 @@ export const getResponsiveCSS = (data: ResponsiveCSSPropertyData[]) => {
     tablet: '',
     laptop: '',
     laptopL: '',
-    desktop: '',
+    desktop: ''
   };
 
   data.forEach(({ prop, propName }) => {

--- a/src/blocks/box/Box.constants.ts
+++ b/src/blocks/box/Box.constants.ts
@@ -1,6 +1,6 @@
 import { BoxCSSProps } from './Box.types';
 
-export const boxCSSPropsKeys: (keyof BoxCSSProps)[] = [
+export const boxRestrictedCSSPropKeys: (keyof BoxCSSProps)[] = [
   'border',
   'borderRadius',
   'backgroundColor',
@@ -11,6 +11,7 @@ export const boxCSSPropsKeys: (keyof BoxCSSProps)[] = [
   'alignItems',
   'display',
   'flexDirection',
+  'gap',
   'height',
   'justifyContent',
   'margin',
@@ -19,5 +20,5 @@ export const boxCSSPropsKeys: (keyof BoxCSSProps)[] = [
   'maxWidth',
   'minWidth',
   'padding',
-  'width',
+  'width'
 ];

--- a/src/blocks/box/Box.tsx
+++ b/src/blocks/box/Box.tsx
@@ -5,14 +5,14 @@ import { BlockWithoutStyleProp } from '../Blocks.types';
 import { getBlocksColor } from '../Blocks.utils';
 import { BoxCSSProps, BoxComponentProps } from './Box.types';
 import { getBoxResponsiveCSS } from './Box.utils';
-import { boxCSSPropsKeys } from './Box.constants';
+import { boxRestrictedCSSPropKeys } from './Box.constants';
 
 export type BoxProps = BoxCSSProps & BoxComponentProps & BlockWithoutStyleProp<HTMLDivElement>;
 
 const StyledBox = styled.div.withConfig({
   shouldForwardProp: (prop, defaultValidatorFn) =>
-    !boxCSSPropsKeys.includes(prop as keyof BoxCSSProps) && defaultValidatorFn(prop),
-})<BoxProps>`
+    !boxRestrictedCSSPropKeys.includes(prop as keyof BoxCSSProps) && defaultValidatorFn(prop),
+}) <BoxProps>`
   /* Responsive props */
   ${(props) => getBoxResponsiveCSS(props)}
 

--- a/src/blocks/box/Box.types.ts
+++ b/src/blocks/box/Box.types.ts
@@ -8,6 +8,8 @@ export type BoxResponsiveProps = {
   alignItems?: ResponsiveProp<CSSProperties['alignItems']>;
   /* Sets flex-direction css property */
   flexDirection?: ResponsiveProp<CSSProperties['flexDirection']>;
+  /* Sets gap between the elements */
+  gap?: ResponsiveProp<SpaceType>;
   /* Sets display css property */
   display?: ResponsiveProp<CSSProperties['display']>;
   /* Sets height css property */
@@ -64,6 +66,7 @@ export type BoxResponsiveCSSProperties =
   | 'align-items'
   | 'display'
   | 'flex-direction'
+  | 'gap'
   | 'height'
   | 'justify-content'
   | 'margin'

--- a/src/blocks/box/Box.utils.ts
+++ b/src/blocks/box/Box.utils.ts
@@ -5,6 +5,7 @@ const getBoxResponsiveCSSProperties = (props: BoxResponsiveProps): BoxResponsive
   { propName: 'align-items', prop: props.alignItems },
   { propName: 'display', prop: props.display },
   { propName: 'flex-direction', prop: props.flexDirection },
+  { propName: 'gap', prop: props.gap },
   { propName: 'height', prop: props.height },
   { propName: 'justify-content', prop: props.justifyContent },
   { propName: 'margin', prop: props.margin },
@@ -13,7 +14,7 @@ const getBoxResponsiveCSSProperties = (props: BoxResponsiveProps): BoxResponsive
   { propName: 'max-width', prop: props.maxWidth },
   { propName: 'min-width', prop: props.minWidth },
   { propName: 'padding', prop: props.padding },
-  { propName: 'width', prop: props.width },
+  { propName: 'width', prop: props.width }
 ];
 
 export const getBoxResponsiveCSS = (props: BoxResponsiveProps) => {


### PR DESCRIPTION
## Pull Request Template

### Ticket Number

#1616 

### Description

Gap prop is added to the Box component and padding and margin props are fixed now.

- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [ ] Bug fix
- [ ] New feature

### Checklist

- [x] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [x] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [ ] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [ ] No errors in the build terminal
- [ ] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- Now, You can use <Box gap='s4' padding='s6 s4 s2 s1'></Box>

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [ ] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

<!-- Any other relevant information or comments: -->
