### PR TITLE
Twitter and discord button states changed

### DIFF
--- a/src/modules/rewards/components/DiscordActivityButton.tsx
+++ b/src/modules/rewards/components/DiscordActivityButton.tsx
@@ -34,6 +34,9 @@ const DiscordActivityButton: FC<DiscordActivityButtonProps> = ({
 
   const { userPushSDKInstance } = useSelector((state: UserStoreType) => state.user);
 
+  const [activityStatus, setActivityStatus] = useState<string | null>(null);
+  const [verifying, setVerifying] = useState(token ? true : false);
+
   useEffect(() => {
     setErrorMessage('');
   }, []);
@@ -63,6 +66,7 @@ const DiscordActivityButton: FC<DiscordActivityButtonProps> = ({
 
   useEffect(() => {
     if (token && userDiscordDetails) {
+      setVerifying(true);
       handleVerify(userPushSDKInstance);
     }
   }, [token, userDiscordDetails]);
@@ -72,7 +76,6 @@ const DiscordActivityButton: FC<DiscordActivityButtonProps> = ({
     activityTypeId,
   });
 
-  const [verifying, setVerifying] = useState(false);
 
   const handleVerify = async (userPushSDKInstance: PushAPI) => {
     if (userDiscordDetails && token) {
@@ -103,6 +106,7 @@ const DiscordActivityButton: FC<DiscordActivityButtonProps> = ({
         {
           onSuccess: (response) => {
             if (response.status === 'COMPLETED') {
+              setActivityStatus('Claimed');
               refetchActivity();
               setVerifying(false);
               setErrorMessage('');
@@ -122,9 +126,9 @@ const DiscordActivityButton: FC<DiscordActivityButtonProps> = ({
 
   return (
     <ActivityStatusButton
-      label="Verify"
-      disabledLabel='Verifying'
-      disabled={verifying}
+      label={activityStatus ? activityStatus : 'Verify'}
+      disabledLabel={activityStatus ? activityStatus : 'Verifying'}
+      disabled={verifying || activityStatus === 'Claimed'}
       onClick={handleVerification}
     />
   );

--- a/src/modules/rewards/components/TwitterActivityButton.tsx
+++ b/src/modules/rewards/components/TwitterActivityButton.tsx
@@ -33,6 +33,7 @@ const TwitterActivityButton: FC<TwitterActivityButtonProps> = ({
 }) => {
   const { userPushSDKInstance } = useSelector((state: UserStoreType) => state.user);
   const [verifying, setVerifying] = useState(false);
+  const [activityStatus, setActivityStatus] = useState<string | null>(null);
 
   //For One case where the error is already present and user relogins the account
   useEffect(() => {
@@ -60,6 +61,7 @@ const TwitterActivityButton: FC<TwitterActivityButtonProps> = ({
         const errorMessage = error.message;
         const credential = TwitterAuthProvider.credentialFromError(error);
         console.log('Error in connecting twitter >>>', errorCode, errorMessage, credential);
+        setVerifying(false);
         return null;
       });
   };
@@ -71,10 +73,10 @@ const TwitterActivityButton: FC<TwitterActivityButtonProps> = ({
 
   const handleVerification = async () => {
     setErrorMessage('');
+    setVerifying(true);
     const userDetails = await handleConnect();
 
     if (userDetails) {
-      setVerifying(true);
 
       // @ts-expect-error
       const twitterHandle = userDetails.reloadUserInfo.screenName;
@@ -107,10 +109,12 @@ const TwitterActivityButton: FC<TwitterActivityButtonProps> = ({
         {
           onSuccess: (response) => {
             if (response.status === 'COMPLETED') {
+              setActivityStatus('Claimed')
               refetchActivity();
               setVerifying(false);
             }
             if (response.status === 'PENDING') {
+              setActivityStatus('Pending')
               refetchActivity();
               setVerifying(false);
             }
@@ -129,10 +133,11 @@ const TwitterActivityButton: FC<TwitterActivityButtonProps> = ({
 
   return (
     <ActivityStatusButton
-      label="Verify"
-      disabled={verifying}
+      label={activityStatus ? activityStatus : 'Verify'}
+      disabledLabel={activityStatus ? activityStatus : 'Verifying'}
+      disabled={verifying || activityStatus === 'Claimed' || activityStatus === 'Pending'}
       onClick={handleVerification}
-      disabledLabel='Verifying'
+
     />
   );
 };


### PR DESCRIPTION
## Pull Request Template

### Ticket Number

<!-- Link to the relevant ticket or issue number: -->
TIcket not created

### Description

- When the twitter or discord button is clicked they go into verifying state instead of Verify and when they are done verifying so they get changed to Pending and Claimed respectively.
- If their is error then the error is displayed at the bottom and then the button state is changed to Verify.


- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

- [ ] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [ ] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [ ] No errors in the build terminal
- [ ] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Explain the previous behavior

- **After:** What's changed now

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [ ] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

https://www.loom.com/share/03597adbdc5a4c9bb8baed0bc49d4a1d?sid=16161e4a-cdaf-4e3d-b486-41de2d4e4c47
