### PR TITLE
Continuous loading state of the profile modal issue fixed

### DIFF
--- a/src/components/chat/unlockProfile/UnlockProfile.tsx
+++ b/src/components/chat/unlockProfile/UnlockProfile.tsx
@@ -42,7 +42,7 @@ const UnlockProfile = ({ InnerComponentProps, onClose }: UnlockProfileModalProps
   const { type } = InnerComponentProps;
 
   const theme = useTheme();
-  const { handleConnectWallet } = useContext(AppContext);
+  const { handleConnectWallet, initializePushSDK } = useContext(AppContext);
 
   const { account, wallet, connect } = useAccount();
 
@@ -82,6 +82,8 @@ const UnlockProfile = ({ InnerComponentProps, onClose }: UnlockProfileModalProps
       const decryptedPGPKeys = retrieveUserPGPKeyFromStorage(account);
       if (decryptedPGPKeys) {
         setIsLoading(true);
+        // If wallet is connected and PGP keys are already present.
+        initializePushSDK(wallet);
       }
     }
 

--- a/src/modules/rewards/components/DashboardSectionPoints.tsx
+++ b/src/modules/rewards/components/DashboardSectionPoints.tsx
@@ -87,7 +87,7 @@ const DashboardSectionPoints: FC<DashboardSectionPointsProps> = ({
               variant="h1-bold"
               color={{ light: 'gray-1000', dark: 'gray-100' }}
             >
-              {points !== undefined ? points : '0'}
+              {points !== undefined ? points?.toLocaleString() : '0'}
             </Text>
           )}
         </Skeleton>

--- a/src/modules/rewards/components/RewardsActivitiesListItem.tsx
+++ b/src/modules/rewards/components/RewardsActivitiesListItem.tsx
@@ -132,7 +132,7 @@ const RewardsActivitiesListItem: FC<RewardActivitiesListItemProps> = ({ userId, 
                     variant="h4-semibold"
                     color={{ light: 'gray-1000', dark: 'gray-100' }}
                   >
-                    {activity.points?.toLocaleString()} points
+                    {activity.points?.toLocaleString()} Points
                   </Text>
                 </Skeleton>
               </Box>

--- a/src/structure/Header.tsx
+++ b/src/structure/Header.tsx
@@ -101,14 +101,14 @@ const RewardsHeaderLink = ({ caip10WalletAddress }: { caip10WalletAddress: strin
             display={{ ml: 'none', dp: 'block' }}
             color={{ light: 'gray-1000', dark: 'gray-100' }}
           >
-            {userDetails && userDetails?.totalPoints > 0 ? userDetails?.totalPoints : ''}
+            {userDetails && userDetails?.totalPoints > 0 ? userDetails?.totalPoints?.toLocaleString() : ''}
           </Text>
           <Text
             variant="h5-bold"
             display={{ ml: 'block', dp: 'none' }}
             color={{ light: 'gray-1000', dark: 'gray-100' }}
           >
-            {userDetails && userDetails?.totalPoints > 0 ? userDetails?.totalPoints : ''}
+            {userDetails && userDetails?.totalPoints > 0 ? userDetails?.totalPoints?.toLocaleString() : ''}
           </Text>
           <Lozenge icon={<Star />}>NEW</Lozenge>
         </Box>


### PR DESCRIPTION
## Pull Request Template

### Ticket Number

No ticket created

### Description

Continuous loading state of the profile modal is fixed. 
When the wallet is connected and PGP keys are present so the modal goes into loading state so fixed that. Now, Push user is initialised at that point and modal gets closed.

- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

- [ ] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [ ] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [ ] No errors in the build terminal
- [ ] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Explain the previous behavior

- **After:** What's changed now

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [ ] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

