### PR TITLE
Support icon sizing according to 'size' prop in blocks button component

### DIFF
--- a/src/blocks/button/Button.utils.ts
+++ b/src/blocks/button/Button.utils.ts
@@ -197,6 +197,11 @@ export const getButtonSizeStyles = ({
       font-weight: 500;
       line-height: 16px;
 
+      .icon {
+        width: 16px;
+        height: 16px;
+      }
+
       .icon-text > span {
         height: 16px;
         width: 16px;
@@ -235,6 +240,11 @@ export const getButtonSizeStyles = ({
       font-style: normal;
       font-weight: 500;
       line-height: 16px;
+
+      .icon {
+        width: 24px;
+        height: 24px;
+      }
 
       .icon-text > span {
         height: 16px;
@@ -276,6 +286,11 @@ export const getButtonSizeStyles = ({
       font-weight: 500;
       line-height: 16px;
 
+      .icon {
+        width: 24px;
+        height: 24px;
+      }
+
       .icon-text > span {
         height: 24px;
         width: 24px;
@@ -314,6 +329,11 @@ export const getButtonSizeStyles = ({
     font-style: normal;
     font-weight: 500;
     line-height: 16px;
+
+    .icon {
+      width: 32px;
+      height: 32px;
+    }
 
     .icon-text > span {
       height: 24px;

--- a/src/blocks/button/Button.utils.ts
+++ b/src/blocks/button/Button.utils.ts
@@ -197,7 +197,7 @@ export const getButtonSizeStyles = ({
       font-weight: 500;
       line-height: 16px;
 
-      .icon {
+      [role='img'] {
         width: 16px;
         height: 16px;
       }
@@ -241,7 +241,7 @@ export const getButtonSizeStyles = ({
       font-weight: 500;
       line-height: 16px;
 
-      .icon {
+      [role='img'] {
         width: 24px;
         height: 24px;
       }
@@ -286,7 +286,7 @@ export const getButtonSizeStyles = ({
       font-weight: 500;
       line-height: 16px;
 
-      .icon {
+      [role='img'] {
         width: 24px;
         height: 24px;
       }
@@ -330,7 +330,7 @@ export const getButtonSizeStyles = ({
     font-weight: 500;
     line-height: 16px;
 
-    .icon {
+    [role='img'] {
       width: 32px;
       height: 32px;
     }


### PR DESCRIPTION
## Pull Request Template

### Ticket Number

<!-- Link to the relevant ticket or issue number: -->

- [1690](https://github.com/push-protocol/push-dapp/issues/1698)

### Description
Currently icons inside buttons component depend upon props passed from outside to handle the icon sizing resulting in an irregularity throughout the Dapp. 

**Problem/Feature**:
- Handle icon sizing internally according to the design.

### Type of Change

<!-- Delete options that are not relevant: -->

- [x] Other (please describe): css changes

### Checklist

- [x] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [x] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [x] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [x] No errors in the build terminal
- [x] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Icons take default size when passed, causing breaking styling.
<img width="90" alt="Screenshot 2024-07-05 at 5 22 05 PM" src="https://github.com/push-protocol/push-dapp/assets/81062983/1e7aab52-408d-4bef-8b7f-ad6dc1cf70b4">




- **After:** Icon sizes depend upon the `size` prop passed and take sizes accordingly.
<img width="80" alt="Screenshot 2024-07-05 at 5 22 21 PM" src="https://github.com/push-protocol/push-dapp/assets/81062983/3667e6ed-2eb2-4c13-a6dd-dc4832b42255">

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [x] Self-review completed
- [ ] Code review by at least one other engineer
- [x] Documentation updates if applicable

### Notes

<!-- Any other relevant information or comments: -->
