### PR TITLE
Fixed the metamask pop up for staking in Yield Farming Page

### DIFF
--- a/src/components/yield/StakingModalComponent.tsx
+++ b/src/components/yield/StakingModalComponent.tsx
@@ -8,14 +8,13 @@ import { ethers } from 'ethers';
 // External Packages
 import styled, { useTheme } from 'styled-components';
 import { MdCheckCircle, MdError } from 'react-icons/md';
-import { useSelector } from 'react-redux';
 
 // Internal Compoonents
 import Close from 'assets/chat/group-chat/close.svg?react';
 import LoaderSpinner, { LOADER_TYPE } from 'components/reusables/loaders/LoaderSpinner';
 import { bnToInt, formatTokens } from 'helpers/StakingHelper';
 import { P } from 'components/SharedStyling';
-import { ButtonV2, H2V2, ItemHV2, ItemVV2, SpanV2 } from 'components/reusables/SharedStylingV2';
+import { ButtonV2, H2V2, ItemHV2, ItemVV2 } from 'components/reusables/SharedStylingV2';
 import { AppContext } from 'contexts/AppContext';
 
 // Internal Configs
@@ -25,7 +24,7 @@ import { useAccount, useDeviceWidthCheck } from 'hooks';
 const StakingModalComponent = ({ onClose, InnerComponentProps, toastObject }) => {
   const { title, getUserData, getPoolStats, setUnstakeErrorMessage, setWithdrawErrorMessage } = InnerComponentProps;
 
-  const { account, provider } = useAccount();
+  const { account, provider, isWalletConnected, connect } = useAccount();
 
   const [maxAmount, setMaxAmount] = useState(0);
   const [approvedToken, setApprovedToken] = useState(0);
@@ -36,9 +35,6 @@ const StakingModalComponent = ({ onClose, InnerComponentProps, toastObject }) =>
 
   const [txnMessage, setTxnMessage] = useState(null);
 
-  const { userPushSDKInstance } = useSelector((state: any) => {
-    return state.user;
-  });
   const { handleConnectWallet } = useContext(AppContext);
 
   const [depositAmount, setDepositAmount] = useState(0);
@@ -85,8 +81,9 @@ const StakingModalComponent = ({ onClose, InnerComponentProps, toastObject }) =>
   }, []);
 
   const approveDeposit = async () => {
-    if (!userPushSDKInstance.signer) {
-      handleConnectWallet();
+
+    if (!isWalletConnected) {
+      connect();
       return;
     }
 
@@ -162,8 +159,8 @@ const StakingModalComponent = ({ onClose, InnerComponentProps, toastObject }) =>
   };
 
   const depositAmountTokenFarmSingleTx = async () => {
-    if (!userPushSDKInstance.signer) {
-      handleConnectWallet();
+    if (!isWalletConnected) {
+      connect();
       return;
     }
 


### PR DESCRIPTION
## Pull Request Template

### Ticket Number

#1730 

### Description

Metamask pop up will not come when the user will try to approve or deposit PUSH token. 
Go to Yield Farming Page -> CLick on Stake PUSH -> before approving PUSH you will need to connect your wallet but metamask pop up will not come. 

Same goes for deposit PUSH also. 

- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

- [ ] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [ ] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [ ] No errors in the build terminal
- [ ] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Explain the previous behavior

- **After:** What's changed now

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [ ] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

<!-- Any other relevant information or comments: -->
