### PR TITLE
 Unlock profile extra step for first time refresh

### DIFF
--- a/src/components/chat/unlockProfile/UnlockProfile.tsx
+++ b/src/components/chat/unlockProfile/UnlockProfile.tsx
@@ -1,5 +1,5 @@
 // React + Web3 Essentials
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 
 // External Packages
 import styled, { useTheme } from 'styled-components';
@@ -66,20 +66,24 @@ const UnlockProfile = ({ InnerComponentProps, onClose }: UnlockProfileModalProps
     body: 'Sign with wallet to continue.',
   });
 
-  const handleRememberMeChange = (event) => {
+  // const handleRememberMeChange = (event: any) => {
+  const handleRememberMeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRememberMe(event.target.checked);
   };
 
-  const handleChatprofileUnlock = async () => {
-    const user = await handleConnectWallet({ remember: rememberMe });
+  const connectWallet = () => {
+    connect();
+  };
 
-    // reject unlock profile listener
+  const handleChatprofileUnlock = useCallback(async () => {
+    const user = await handleConnectWallet({ remember: rememberMe, wallet });
+
     const errorExists = checkUnlockProfileErrors(user);
 
     if (errorExists && onClose) {
       onClose();
     }
-  };
+  }, [wallet, rememberMe]);
 
   useEffect(() => {
     if (wallet?.accounts?.length > 0) {
@@ -228,7 +232,7 @@ const UnlockProfile = ({ InnerComponentProps, onClose }: UnlockProfileModalProps
                   activeStatus={activeStatus.status}
                   status={PROFILESTATE.CONNECT_WALLET}
                   disabled={activeStatus.status !== PROFILESTATE.CONNECT_WALLET && true}
-                  onClick={() => connect()}
+                  onClick={() => connectWallet()}
                 >
                   Connect Wallet
                 </DefaultButton>

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -33,6 +33,7 @@ const AppContextProvider = ({ children }) => {
   const shouldInitializeRef = useRef(true); // Using a ref to control useEffect execution
 
   const { connect, provider, account, wallet, connecting } = useAccount();
+
   const web3onboardToast = useToast();
 
   const { readOnlyWallet } = useContext(GlobalContext);
@@ -96,7 +97,17 @@ const AppContextProvider = ({ children }) => {
   };
 
   // TODO: Change function name to handleConnectWalletAndUser
-  const handleConnectWallet = async ({ remember = false, showToast = false, toastMessage = undefined } = {}) => {
+  const handleConnectWallet = async ({
+    remember = false,
+    showToast = false,
+    toastMessage = undefined,
+    wallet,
+  }: {
+    wallet?: any;
+    remember?: any;
+    showToast?: boolean;
+    toastMessage?: string;
+  }) => {
     shouldInitializeRef.current = false; // Directly modify the ref to disable useEffect execution
 
     if (showToast) {
@@ -116,7 +127,7 @@ const AppContextProvider = ({ children }) => {
     let user;
 
     if (wallet?.accounts?.length > 0) {
-      user = await initializePushSDK();
+      user = await initializePushSDK(wallet);
     } else {
       const walletConnected = await connect();
       if (walletConnected.length > 0) {


### PR DESCRIPTION
## Pull Request Template

#1725 

### Description

<!-- Briefly describe the problem this PR addresses or the feature added: -->

- When you unlock profile, either in rewards or chat. For the first time, as you connect wallet, you should get the unlock profile modal. It should take you to the popup to sign or reject the push profile instead of popping up the connect wallet blocknative modal again
- Remember me not passing the the actual value to the handleConnectWallet function

- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

- [ ] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [x] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [x] No errors in the build terminal
- [x] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Explain the previous behavior

- **After:** What's changed now

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [x] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

<!-- Any other relevant information or comments: -->
