### PR TITLE
Fixed the disabling of opt-in button during blocknative modal

### DIFF
--- a/src/components/ViewChannelItem.jsx
+++ b/src/components/ViewChannelItem.jsx
@@ -450,19 +450,19 @@ function ViewChannelItem({ channelObjectProp, loadTeaser, playTeaser, minimal, p
                           placementProps={
                             tooltTipHeight < 250
                               ? {
-                                  background: 'none',
-                                  // bottom: "25px",
-                                  top: '20px',
-                                  // right: "-175px",
-                                  left: mobileToolTip ? '-100px' : '5px',
-                                }
+                                background: 'none',
+                                // bottom: "25px",
+                                top: '20px',
+                                // right: "-175px",
+                                left: mobileToolTip ? '-100px' : '5px',
+                              }
                               : {
-                                  background: 'none',
-                                  bottom: '25px',
-                                  // top: "20px",
-                                  // right: "-175px",
-                                  left: mobileToolTip ? '-100px' : '5px',
-                                }
+                                background: 'none',
+                                bottom: '25px',
+                                // top: "20px",
+                                // right: "-175px",
+                                left: mobileToolTip ? '-100px' : '5px',
+                              }
                           }
                           tooltipContent={
                             <UpdateChannelTooltipContent
@@ -508,15 +508,15 @@ function ViewChannelItem({ channelObjectProp, loadTeaser, playTeaser, minimal, p
                           placementProps={
                             tooltTipHeight < 160
                               ? {
-                                  background: 'none',
-                                  top: '20px', // for lower displaying
-                                  left: '7px',
-                                }
+                                background: 'none',
+                                top: '20px', // for lower displaying
+                                left: '7px',
+                              }
                               : {
-                                  background: 'none',
-                                  bottom: '28px', // above display
-                                  left: '7px',
-                                }
+                                background: 'none',
+                                bottom: '28px', // above display
+                                left: '7px',
+                              }
                           }
                           tooltipContent={
                             <VerifiedTooltipContent
@@ -624,19 +624,19 @@ function ViewChannelItem({ channelObjectProp, loadTeaser, playTeaser, minimal, p
                         placementProps={
                           tooltTipHeight < 250
                             ? {
-                                background: 'none',
-                                // bottom: "25px",
-                                top: '20px',
-                                // right: "-175px",
-                                left: '5px',
-                              }
+                              background: 'none',
+                              // bottom: "25px",
+                              top: '20px',
+                              // right: "-175px",
+                              left: '5px',
+                            }
                             : {
-                                background: 'none',
-                                bottom: '25px',
-                                // top: "20px",
-                                // right: "-175px",
-                                left: '5px',
-                              }
+                              background: 'none',
+                              bottom: '25px',
+                              // top: "20px",
+                              // right: "-175px",
+                              left: '5px',
+                            }
                         }
                         tooltipContent={
                           <UpdateChannelTooltipContent
@@ -680,15 +680,15 @@ function ViewChannelItem({ channelObjectProp, loadTeaser, playTeaser, minimal, p
                           placementProps={
                             tooltTipHeight < 160
                               ? {
-                                  background: 'none',
-                                  top: '20px', // for lower displaying
-                                  left: '7px',
-                                }
+                                background: 'none',
+                                top: '20px', // for lower displaying
+                                left: '7px',
+                              }
                               : {
-                                  background: 'none',
-                                  bottom: '28px', // above display
-                                  left: '7px',
-                                }
+                                background: 'none',
+                                bottom: '28px', // above display
+                                left: '7px',
+                              }
                           }
                           tooltipContent={
                             <VerifiedTooltipContent
@@ -956,19 +956,11 @@ function ViewChannelItem({ channelObjectProp, loadTeaser, playTeaser, minimal, p
                   >
                     <Button
                       size="small"
-                      onClick={() => {}}
+                      onClick={() => { }}
                       disabled={txInProgress}
+                      loading={txInProgress}
                     >
-                      {txInProgress && (
-                        <ActionLoader>
-                          <LoaderSpinner
-                            type={LOADER_TYPE.SEAMLESS}
-                            spinnerSize={16}
-                            spinnerColor="#FFF"
-                          />
-                        </ActionLoader>
-                      )}
-                      <ActionTitle hideit={txInProgress}>Opt-In</ActionTitle>
+                      {!txInProgress && 'Opt-In'}
                     </Button>
                   </OptinNotifSettingDropdown>
                 )}
@@ -1005,7 +997,7 @@ function ViewChannelItem({ channelObjectProp, loadTeaser, playTeaser, minimal, p
                     }}
                   >
                     <UnsubscribeButton
-                      onClick={() => {}}
+                      onClick={() => { }}
                       disabled={txInProgress}
                     >
                       {txInProgress && (

--- a/src/components/dropdowns/OptinNotifSettingDropdown.tsx
+++ b/src/components/dropdowns/OptinNotifSettingDropdown.tsx
@@ -217,8 +217,8 @@ const OptinNotifSettingDropdown: FC<OptinNotifSettingDropdownProps> = (options) 
     channelSettings?: ChannelSetting[];
     setLoading?: Dispatch<SetStateAction<boolean>>;
   }) => {
-    const setLoadingFunc = setLoading || (options && options.setLoading) || (() => {});
-    setLoadingFunc(true);
+    const setLoadingFunc = setLoading || (options && options.setLoading) || (() => { });
+
 
     let userPushInstance = userPushSDKInstance;
     // if (!userPushInstance.signer) {
@@ -239,6 +239,7 @@ const OptinNotifSettingDropdown: FC<OptinNotifSettingDropdownProps> = (options) 
     }
 
     try {
+      setLoadingFunc(true);
       let channelAddress = channelDetail.channel;
       if (!onCoreNetwork) {
         channelAddress = channelDetail.alias_address;


### PR DESCRIPTION
## Pull Request Template

#1837 

### Description

Opt-In will show loader when the opt-In is in progress

- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

- [ ] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [ ] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [ ] No errors in the build terminal
- [ ] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

This issue that Siddharth pointed out in slack thread
<img width="1017" alt="Screenshot 2024-08-30 at 2 57 21 PM" src="https://github.com/user-attachments/assets/224edced-f207-48cb-9094-f077a61007ef">


- **Before:** Explain the previous behavior

- **After:** What's changed now

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [ ] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

<!-- Any other relevant information or comments: -->

