### PR TITLE
Fix Expiry time in Rewards Activities

### DIFF
--- a/src/modules/rewards/components/RewardsActivitiesListItem.tsx
+++ b/src/modules/rewards/components/RewardsActivitiesListItem.tsx
@@ -30,9 +30,15 @@ export type RewardActivitiesListItemProps = {
 };
 
 const getUpdatedExpiryTime = (timestamp: number) => {
-  const date = new Date(timestamp * 1000);
-  const days = date.getDate();
-  return days;
+  const currentDate = new Date();
+  const expiryDate = new Date(timestamp * 1000);
+
+  // Calculate the difference in time (milliseconds)
+  const timeDiff = expiryDate.getTime() - currentDate.getTime();
+
+  // Convert the difference from milliseconds to days
+  const daysLeft = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
+  return daysLeft;
 };
 
 const RewardsActivitiesListItem: FC<RewardActivitiesListItemProps> = ({
@@ -144,7 +150,7 @@ const RewardsActivitiesListItem: FC<RewardActivitiesListItemProps> = ({
                     display="flex"
                     gap="spacing-xxs"
                   >
-                    {!!activity.expiryType && (
+                    {!!activity.expiryType && getUpdatedExpiryTime(activity?.expiryType) > 0 && (
                       <Lozenge size="small">
                         {`Expires in ${getUpdatedExpiryTime(activity?.expiryType)} days`.toUpperCase()}
                       </Lozenge>


### PR DESCRIPTION
## Pull Request Template

#1902 

### Description

<!-- Briefly describe the problem this PR addresses or the feature added: -->

Expiry time in Rewards Points(Quickswap channel) should show days left, not the day of the month

- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

- [x] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [x] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [x] No errors in the build terminal
- [x] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Explain the previous behavior

- **After:** What's changed now

### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [ ] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

<!-- Any other relevant information or comments: -->
