### PR TITLE
🐛 [BUG] - <FireFox UI flaws/issues>

### DIFF
--- a/src/blocks/box/Box.tsx
+++ b/src/blocks/box/Box.tsx
@@ -27,6 +27,17 @@ const StyledBox = styled.div.withConfig({
   border: ${(props) => getBlocksBorder(props.border)};
   position: ${(props) => props.position};
 
+  ${(props) => {
+    if (props.width === '-webkit-fill-available') {
+      return `
+        width: 100%; /* Fallback for all browsers */
+        width: -moz-available; /* Firefox */
+        width: -webkit-fill-available; /* Chrome, Safari */
+      `;
+    }
+    return `width: ${props.width};`;
+  }}
+
   // push custom scroll
   ${(props) =>
     props.customScrollbar &&


### PR DESCRIPTION
## Pull Request Template

#1952 

### Description

<!-- Briefly describe the problem this PR addresses or the feature added: -->

- UI issues(bugs) in FireFox browser

- **Problem/Feature**:

### Type of Change

<!-- Delete options that are not relevant: -->

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

- [ ] **Quick PR**: Is this a quick PR? Can be approved before finishing a coffee.
  - [ ] Quick PR label added
- [ ] **Not Merge Ready**: Is this PR dependent on some other PR/tasks and not ready to be merged right now.
  - [ ] DO NOT Merge PR label added

### Frontend Guidelines

<!-- Ensure all frontend guidelines are met as per the guidelines Notion doc: -->

- [x] Followed frontend guidelines as per the [Guidelines Notion Doc](https://www.notion.so/pushprotocol/Frontend-dApp-Guidelines-1d7806ae3d9e4569a340b563dcd0536c)

### Build & Testing

- [x] No errors in the build terminal
- [x] Engineer has tested the changes on their local environment
- [ ] Engineer has tested the changes on deploy preview

### Screenshots/Video with Explanation

<!-- If applicable, add screenshots to help explain your changes: -->

- **Before:** Explain the previous behavior
width: -webkit-fill-available not working in Firefox is due to the fact that Firefox does not support the -webkit- prefixed property. T
<img width="1512" alt="Screenshot 2025-01-26 at 20 33 10" src="https://github.com/user-attachments/assets/56f9cc77-9a3a-4913-9344-055f9fd89e81" />


- **After:** What's changed now
<img width="1512" alt="Screenshot 2025-01-26 at 20 33 39" src="https://github.com/user-attachments/assets/3ba2ffde-1f3d-4000-9a72-a4c707247c66" />


### Additional Context

<!-- Add any other context or information that reviewers might need: -->

### Review & Approvals

- [x] Self-review completed
- [ ] Code review by at least one other engineer
- [ ] Documentation updates if applicable

### Notes

<!-- Any other relevant information or comments: -->
